### PR TITLE
fix: synchronize icall method providers

### DIFF
--- a/cmd/icall_gen/_data/icall.go
+++ b/cmd/icall_gen/_data/icall.go
@@ -11,6 +11,8 @@ package $pkgname
 
 import (
 	"reflect"
+	"runtime"
+	"sync"
 	"unsafe"
 
 	"github.com/goplus/reflectx/abi"
@@ -19,37 +21,49 @@ import (
 const capacity = $max_size
 
 type provider struct {
+	mu   sync.RWMutex
 	used []*abi.MethodInfo
 	n    int
 }
 
 func (p *provider) Insert(info *abi.MethodInfo) (ifn unsafe.Pointer, index int) {
+	p.mu.Lock()
 	for i := 0; i < capacity; i++ {
 		if p.used[i] == nil {
 			p.n++
 			p.used[i] = info
 			fn := icall_array[i]
+			p.mu.Unlock()
 			return unsafe.Pointer(reflect.ValueOf(fn).Pointer()), i
 		}
 	}
+	p.mu.Unlock()
 	return nil, -1
 }
 
 func (p *provider) Available() int {
-	return capacity - p.n
+	p.mu.RLock()
+	n := capacity - p.n
+	p.mu.RUnlock()
+	return n
 }
 
 func (p *provider) Remove(indexs []int) {
+	p.mu.Lock()
 	for _, n := range indexs {
 		if n < capacity && p.used[n] != nil {
 			p.used[n] = nil
 			p.n--
 		}
 	}
+	p.mu.Unlock()
 }
 
 func (p *provider) Used() int {
-	return p.n
+	p.mu.RLock()
+	n := p.n
+	p.mu.RUnlock()
+	return n
 }
 
 func (p *provider) Cap() int {
@@ -57,8 +71,17 @@ func (p *provider) Cap() int {
 }
 
 func (p *provider) Clear() {
+	p.mu.Lock()
 	clear(p.used)
 	p.n = 0
+	p.mu.Unlock()
+}
+
+func (p *provider) lookup(index int) *abi.MethodInfo {
+	p.mu.RLock()
+	info := p.used[index]
+	p.mu.RUnlock()
+	return info
 }
 
 var (
@@ -72,7 +95,7 @@ func init() {
 }
 
 func i_x(index int, ptr unsafe.Pointer, p unsafe.Pointer) {
-	info := mp.used[index]
+	info := mp.lookup(index)
 	var receiver reflect.Value
 	if !info.Pointer && info.OnePtr {
 		receiver = reflect.NewAt(info.Type, unsafe.Pointer(&ptr)).Elem()
@@ -118,6 +141,9 @@ func i_x(index int, ptr unsafe.Pointer, p unsafe.Pointer) {
 			*(*byte)(add(p, info.InSize+i, "")) = *(*byte)(add(po, uintptr(i), ""))
 		}
 	}
+	// Context.Reset may clear the slot after lookup. Keep the copied method alive
+	// until the call returns without holding the provider lock over user code.
+	runtime.KeepAlive(info)
 }
 
 func add(p unsafe.Pointer, x uintptr, whySafe string) unsafe.Pointer {

--- a/cmd/icall_gen/_data/icall_regabi.go
+++ b/cmd/icall_gen/_data/icall_regabi.go
@@ -5,6 +5,8 @@ package $pkgname
 
 import (
 	"reflect"
+	"runtime"
+	"sync"
 	"unsafe"
 
 	"github.com/goplus/reflectx/abi"
@@ -18,20 +20,26 @@ type methodUsed struct {
 }
 
 type provider struct {
+	mu   sync.RWMutex
 	used []*methodUsed
 	n    int
 }
 
 func i_x(c unsafe.Pointer, frame unsafe.Pointer, retValid *bool, r unsafe.Pointer, index int) {
-	ptr := mp.used[index].ptr
+	method := mp.lookup(index)
+	ptr := method.ptr
 	moveMakeFuncArgPtrs(ptr, r)
 	callReflect(ptr, frame, retValid, r)
+	// Context.Reset may clear the slot after lookup. Keep the copied method alive
+	// until callReflect returns without holding the provider lock over user code.
+	runtime.KeepAlive(method)
 }
 
 func spillArgs()
 func unspillArgs()
 
 func (p *provider) Insert(info *abi.MethodInfo) (unsafe.Pointer, int) {
+	p.mu.Lock()
 	var index = -1
 	for i := 0; i < capacity; i++ {
 		if p.used[i] == nil {
@@ -40,6 +48,7 @@ func (p *provider) Insert(info *abi.MethodInfo) (unsafe.Pointer, int) {
 		}
 	}
 	if index == -1 {
+		p.mu.Unlock()
 		return nil, -1
 	}
 	var fn reflect.Value
@@ -77,24 +86,33 @@ func (p *provider) Insert(info *abi.MethodInfo) (unsafe.Pointer, int) {
 	}
 	p.n++
 	icall := icall_fn[index]
+	p.mu.Unlock()
 	return unsafe.Pointer(reflect.ValueOf(icall).Pointer()), index
 }
 
 func (p *provider) Remove(indexs []int) {
+	p.mu.Lock()
 	for _, n := range indexs {
 		if n < capacity && p.used[n] != nil {
 			p.used[n] = nil
 			p.n--
 		}
 	}
+	p.mu.Unlock()
 }
 
 func (p *provider) Available() int {
-	return capacity - p.n
+	p.mu.RLock()
+	n := capacity - p.n
+	p.mu.RUnlock()
+	return n
 }
 
 func (p *provider) Used() int {
-	return p.n
+	p.mu.RLock()
+	n := p.n
+	p.mu.RUnlock()
+	return n
 }
 
 func (p *provider) Cap() int {
@@ -102,8 +120,17 @@ func (p *provider) Cap() int {
 }
 
 func (p *provider) Clear() {
+	p.mu.Lock()
 	clear(p.used)
 	p.n = 0
+	p.mu.Unlock()
+}
+
+func (p *provider) lookup(index int) *methodUsed {
+	p.mu.RLock()
+	method := p.used[index]
+	p.mu.RUnlock()
+	return method
 }
 
 var (

--- a/icall/icall1024/icall.go
+++ b/icall/icall1024/icall.go
@@ -11,6 +11,8 @@ package icall
 
 import (
 	"reflect"
+	"runtime"
+	"sync"
 	"unsafe"
 
 	"github.com/goplus/reflectx/abi"
@@ -19,37 +21,49 @@ import (
 const capacity = 1024
 
 type provider struct {
+	mu   sync.RWMutex
 	used []*abi.MethodInfo
 	n    int
 }
 
 func (p *provider) Insert(info *abi.MethodInfo) (ifn unsafe.Pointer, index int) {
+	p.mu.Lock()
 	for i := 0; i < capacity; i++ {
 		if p.used[i] == nil {
 			p.n++
 			p.used[i] = info
 			fn := icall_array[i]
+			p.mu.Unlock()
 			return unsafe.Pointer(reflect.ValueOf(fn).Pointer()), i
 		}
 	}
+	p.mu.Unlock()
 	return nil, -1
 }
 
 func (p *provider) Available() int {
-	return capacity - p.n
+	p.mu.RLock()
+	n := capacity - p.n
+	p.mu.RUnlock()
+	return n
 }
 
 func (p *provider) Remove(indexs []int) {
+	p.mu.Lock()
 	for _, n := range indexs {
 		if n < capacity && p.used[n] != nil {
 			p.used[n] = nil
 			p.n--
 		}
 	}
+	p.mu.Unlock()
 }
 
 func (p *provider) Used() int {
-	return p.n
+	p.mu.RLock()
+	n := p.n
+	p.mu.RUnlock()
+	return n
 }
 
 func (p *provider) Cap() int {
@@ -57,8 +71,17 @@ func (p *provider) Cap() int {
 }
 
 func (p *provider) Clear() {
+	p.mu.Lock()
 	clear(p.used)
 	p.n = 0
+	p.mu.Unlock()
+}
+
+func (p *provider) lookup(index int) *abi.MethodInfo {
+	p.mu.RLock()
+	info := p.used[index]
+	p.mu.RUnlock()
+	return info
 }
 
 var (
@@ -72,7 +95,7 @@ func init() {
 }
 
 func i_x(index int, ptr unsafe.Pointer, p unsafe.Pointer) {
-	info := mp.used[index]
+	info := mp.lookup(index)
 	var receiver reflect.Value
 	if !info.Pointer && info.OnePtr {
 		receiver = reflect.NewAt(info.Type, unsafe.Pointer(&ptr)).Elem()
@@ -118,6 +141,9 @@ func i_x(index int, ptr unsafe.Pointer, p unsafe.Pointer) {
 			*(*byte)(add(p, info.InSize+i, "")) = *(*byte)(add(po, uintptr(i), ""))
 		}
 	}
+	// Context.Reset may clear the slot after lookup. Keep the copied method alive
+	// until the call returns without holding the provider lock over user code.
+	runtime.KeepAlive(info)
 }
 
 func add(p unsafe.Pointer, x uintptr, whySafe string) unsafe.Pointer {
@@ -125,6 +151,7 @@ func add(p unsafe.Pointer, x uintptr, whySafe string) unsafe.Pointer {
 }
 
 type unsafeptr = unsafe.Pointer
+
 
 var icall_array = []interface{}{
 	func(p, a unsafeptr) { i_x(0, p, unsafeptr(&a)) },

--- a/icall/icall1024/icall_regabi.go
+++ b/icall/icall1024/icall_regabi.go
@@ -5,6 +5,8 @@ package icall
 
 import (
 	"reflect"
+	"runtime"
+	"sync"
 	"unsafe"
 
 	"github.com/goplus/reflectx/abi"
@@ -18,20 +20,26 @@ type methodUsed struct {
 }
 
 type provider struct {
+	mu   sync.RWMutex
 	used []*methodUsed
 	n    int
 }
 
 func i_x(c unsafe.Pointer, frame unsafe.Pointer, retValid *bool, r unsafe.Pointer, index int) {
-	ptr := mp.used[index].ptr
+	method := mp.lookup(index)
+	ptr := method.ptr
 	moveMakeFuncArgPtrs(ptr, r)
 	callReflect(ptr, frame, retValid, r)
+	// Context.Reset may clear the slot after lookup. Keep the copied method alive
+	// until callReflect returns without holding the provider lock over user code.
+	runtime.KeepAlive(method)
 }
 
 func spillArgs()
 func unspillArgs()
 
 func (p *provider) Insert(info *abi.MethodInfo) (unsafe.Pointer, int) {
+	p.mu.Lock()
 	var index = -1
 	for i := 0; i < capacity; i++ {
 		if p.used[i] == nil {
@@ -40,6 +48,7 @@ func (p *provider) Insert(info *abi.MethodInfo) (unsafe.Pointer, int) {
 		}
 	}
 	if index == -1 {
+		p.mu.Unlock()
 		return nil, -1
 	}
 	var fn reflect.Value
@@ -77,24 +86,33 @@ func (p *provider) Insert(info *abi.MethodInfo) (unsafe.Pointer, int) {
 	}
 	p.n++
 	icall := icall_fn[index]
+	p.mu.Unlock()
 	return unsafe.Pointer(reflect.ValueOf(icall).Pointer()), index
 }
 
 func (p *provider) Remove(indexs []int) {
+	p.mu.Lock()
 	for _, n := range indexs {
 		if n < capacity && p.used[n] != nil {
 			p.used[n] = nil
 			p.n--
 		}
 	}
+	p.mu.Unlock()
 }
 
 func (p *provider) Available() int {
-	return capacity - p.n
+	p.mu.RLock()
+	n := capacity - p.n
+	p.mu.RUnlock()
+	return n
 }
 
 func (p *provider) Used() int {
-	return p.n
+	p.mu.RLock()
+	n := p.n
+	p.mu.RUnlock()
+	return n
 }
 
 func (p *provider) Cap() int {
@@ -102,8 +120,17 @@ func (p *provider) Cap() int {
 }
 
 func (p *provider) Clear() {
+	p.mu.Lock()
 	clear(p.used)
 	p.n = 0
+	p.mu.Unlock()
+}
+
+func (p *provider) lookup(index int) *methodUsed {
+	p.mu.RLock()
+	method := p.used[index]
+	p.mu.RUnlock()
+	return method
 }
 
 var (

--- a/icall/icall10240/icall.go
+++ b/icall/icall10240/icall.go
@@ -11,6 +11,8 @@ package icall
 
 import (
 	"reflect"
+	"runtime"
+	"sync"
 	"unsafe"
 
 	"github.com/goplus/reflectx/abi"
@@ -19,37 +21,49 @@ import (
 const capacity = 10240
 
 type provider struct {
+	mu   sync.RWMutex
 	used []*abi.MethodInfo
 	n    int
 }
 
 func (p *provider) Insert(info *abi.MethodInfo) (ifn unsafe.Pointer, index int) {
+	p.mu.Lock()
 	for i := 0; i < capacity; i++ {
 		if p.used[i] == nil {
 			p.n++
 			p.used[i] = info
 			fn := icall_array[i]
+			p.mu.Unlock()
 			return unsafe.Pointer(reflect.ValueOf(fn).Pointer()), i
 		}
 	}
+	p.mu.Unlock()
 	return nil, -1
 }
 
 func (p *provider) Available() int {
-	return capacity - p.n
+	p.mu.RLock()
+	n := capacity - p.n
+	p.mu.RUnlock()
+	return n
 }
 
 func (p *provider) Remove(indexs []int) {
+	p.mu.Lock()
 	for _, n := range indexs {
 		if n < capacity && p.used[n] != nil {
 			p.used[n] = nil
 			p.n--
 		}
 	}
+	p.mu.Unlock()
 }
 
 func (p *provider) Used() int {
-	return p.n
+	p.mu.RLock()
+	n := p.n
+	p.mu.RUnlock()
+	return n
 }
 
 func (p *provider) Cap() int {
@@ -57,8 +71,17 @@ func (p *provider) Cap() int {
 }
 
 func (p *provider) Clear() {
+	p.mu.Lock()
 	clear(p.used)
 	p.n = 0
+	p.mu.Unlock()
+}
+
+func (p *provider) lookup(index int) *abi.MethodInfo {
+	p.mu.RLock()
+	info := p.used[index]
+	p.mu.RUnlock()
+	return info
 }
 
 var (
@@ -72,7 +95,7 @@ func init() {
 }
 
 func i_x(index int, ptr unsafe.Pointer, p unsafe.Pointer) {
-	info := mp.used[index]
+	info := mp.lookup(index)
 	var receiver reflect.Value
 	if !info.Pointer && info.OnePtr {
 		receiver = reflect.NewAt(info.Type, unsafe.Pointer(&ptr)).Elem()
@@ -118,6 +141,9 @@ func i_x(index int, ptr unsafe.Pointer, p unsafe.Pointer) {
 			*(*byte)(add(p, info.InSize+i, "")) = *(*byte)(add(po, uintptr(i), ""))
 		}
 	}
+	// Context.Reset may clear the slot after lookup. Keep the copied method alive
+	// until the call returns without holding the provider lock over user code.
+	runtime.KeepAlive(info)
 }
 
 func add(p unsafe.Pointer, x uintptr, whySafe string) unsafe.Pointer {
@@ -125,6 +151,7 @@ func add(p unsafe.Pointer, x uintptr, whySafe string) unsafe.Pointer {
 }
 
 type unsafeptr = unsafe.Pointer
+
 
 var icall_array = []interface{}{
 	func(p, a unsafeptr) { i_x(0, p, unsafeptr(&a)) },

--- a/icall/icall10240/icall_regabi.go
+++ b/icall/icall10240/icall_regabi.go
@@ -5,6 +5,8 @@ package icall
 
 import (
 	"reflect"
+	"runtime"
+	"sync"
 	"unsafe"
 
 	"github.com/goplus/reflectx/abi"
@@ -18,20 +20,26 @@ type methodUsed struct {
 }
 
 type provider struct {
+	mu   sync.RWMutex
 	used []*methodUsed
 	n    int
 }
 
 func i_x(c unsafe.Pointer, frame unsafe.Pointer, retValid *bool, r unsafe.Pointer, index int) {
-	ptr := mp.used[index].ptr
+	method := mp.lookup(index)
+	ptr := method.ptr
 	moveMakeFuncArgPtrs(ptr, r)
 	callReflect(ptr, frame, retValid, r)
+	// Context.Reset may clear the slot after lookup. Keep the copied method alive
+	// until callReflect returns without holding the provider lock over user code.
+	runtime.KeepAlive(method)
 }
 
 func spillArgs()
 func unspillArgs()
 
 func (p *provider) Insert(info *abi.MethodInfo) (unsafe.Pointer, int) {
+	p.mu.Lock()
 	var index = -1
 	for i := 0; i < capacity; i++ {
 		if p.used[i] == nil {
@@ -40,6 +48,7 @@ func (p *provider) Insert(info *abi.MethodInfo) (unsafe.Pointer, int) {
 		}
 	}
 	if index == -1 {
+		p.mu.Unlock()
 		return nil, -1
 	}
 	var fn reflect.Value
@@ -77,24 +86,33 @@ func (p *provider) Insert(info *abi.MethodInfo) (unsafe.Pointer, int) {
 	}
 	p.n++
 	icall := icall_fn[index]
+	p.mu.Unlock()
 	return unsafe.Pointer(reflect.ValueOf(icall).Pointer()), index
 }
 
 func (p *provider) Remove(indexs []int) {
+	p.mu.Lock()
 	for _, n := range indexs {
 		if n < capacity && p.used[n] != nil {
 			p.used[n] = nil
 			p.n--
 		}
 	}
+	p.mu.Unlock()
 }
 
 func (p *provider) Available() int {
-	return capacity - p.n
+	p.mu.RLock()
+	n := capacity - p.n
+	p.mu.RUnlock()
+	return n
 }
 
 func (p *provider) Used() int {
-	return p.n
+	p.mu.RLock()
+	n := p.n
+	p.mu.RUnlock()
+	return n
 }
 
 func (p *provider) Cap() int {
@@ -102,8 +120,17 @@ func (p *provider) Cap() int {
 }
 
 func (p *provider) Clear() {
+	p.mu.Lock()
 	clear(p.used)
 	p.n = 0
+	p.mu.Unlock()
+}
+
+func (p *provider) lookup(index int) *methodUsed {
+	p.mu.RLock()
+	method := p.used[index]
+	p.mu.RUnlock()
+	return method
 }
 
 var (

--- a/icall/icall2048/icall.go
+++ b/icall/icall2048/icall.go
@@ -11,6 +11,8 @@ package icall
 
 import (
 	"reflect"
+	"runtime"
+	"sync"
 	"unsafe"
 
 	"github.com/goplus/reflectx/abi"
@@ -19,37 +21,49 @@ import (
 const capacity = 2048
 
 type provider struct {
+	mu   sync.RWMutex
 	used []*abi.MethodInfo
 	n    int
 }
 
 func (p *provider) Insert(info *abi.MethodInfo) (ifn unsafe.Pointer, index int) {
+	p.mu.Lock()
 	for i := 0; i < capacity; i++ {
 		if p.used[i] == nil {
 			p.n++
 			p.used[i] = info
 			fn := icall_array[i]
+			p.mu.Unlock()
 			return unsafe.Pointer(reflect.ValueOf(fn).Pointer()), i
 		}
 	}
+	p.mu.Unlock()
 	return nil, -1
 }
 
 func (p *provider) Available() int {
-	return capacity - p.n
+	p.mu.RLock()
+	n := capacity - p.n
+	p.mu.RUnlock()
+	return n
 }
 
 func (p *provider) Remove(indexs []int) {
+	p.mu.Lock()
 	for _, n := range indexs {
 		if n < capacity && p.used[n] != nil {
 			p.used[n] = nil
 			p.n--
 		}
 	}
+	p.mu.Unlock()
 }
 
 func (p *provider) Used() int {
-	return p.n
+	p.mu.RLock()
+	n := p.n
+	p.mu.RUnlock()
+	return n
 }
 
 func (p *provider) Cap() int {
@@ -57,8 +71,17 @@ func (p *provider) Cap() int {
 }
 
 func (p *provider) Clear() {
+	p.mu.Lock()
 	clear(p.used)
 	p.n = 0
+	p.mu.Unlock()
+}
+
+func (p *provider) lookup(index int) *abi.MethodInfo {
+	p.mu.RLock()
+	info := p.used[index]
+	p.mu.RUnlock()
+	return info
 }
 
 var (
@@ -72,7 +95,7 @@ func init() {
 }
 
 func i_x(index int, ptr unsafe.Pointer, p unsafe.Pointer) {
-	info := mp.used[index]
+	info := mp.lookup(index)
 	var receiver reflect.Value
 	if !info.Pointer && info.OnePtr {
 		receiver = reflect.NewAt(info.Type, unsafe.Pointer(&ptr)).Elem()
@@ -118,6 +141,9 @@ func i_x(index int, ptr unsafe.Pointer, p unsafe.Pointer) {
 			*(*byte)(add(p, info.InSize+i, "")) = *(*byte)(add(po, uintptr(i), ""))
 		}
 	}
+	// Context.Reset may clear the slot after lookup. Keep the copied method alive
+	// until the call returns without holding the provider lock over user code.
+	runtime.KeepAlive(info)
 }
 
 func add(p unsafe.Pointer, x uintptr, whySafe string) unsafe.Pointer {
@@ -125,6 +151,7 @@ func add(p unsafe.Pointer, x uintptr, whySafe string) unsafe.Pointer {
 }
 
 type unsafeptr = unsafe.Pointer
+
 
 var icall_array = []interface{}{
 	func(p, a unsafeptr) { i_x(0, p, unsafeptr(&a)) },

--- a/icall/icall2048/icall_regabi.go
+++ b/icall/icall2048/icall_regabi.go
@@ -5,6 +5,8 @@ package icall
 
 import (
 	"reflect"
+	"runtime"
+	"sync"
 	"unsafe"
 
 	"github.com/goplus/reflectx/abi"
@@ -18,20 +20,26 @@ type methodUsed struct {
 }
 
 type provider struct {
+	mu   sync.RWMutex
 	used []*methodUsed
 	n    int
 }
 
 func i_x(c unsafe.Pointer, frame unsafe.Pointer, retValid *bool, r unsafe.Pointer, index int) {
-	ptr := mp.used[index].ptr
+	method := mp.lookup(index)
+	ptr := method.ptr
 	moveMakeFuncArgPtrs(ptr, r)
 	callReflect(ptr, frame, retValid, r)
+	// Context.Reset may clear the slot after lookup. Keep the copied method alive
+	// until callReflect returns without holding the provider lock over user code.
+	runtime.KeepAlive(method)
 }
 
 func spillArgs()
 func unspillArgs()
 
 func (p *provider) Insert(info *abi.MethodInfo) (unsafe.Pointer, int) {
+	p.mu.Lock()
 	var index = -1
 	for i := 0; i < capacity; i++ {
 		if p.used[i] == nil {
@@ -40,6 +48,7 @@ func (p *provider) Insert(info *abi.MethodInfo) (unsafe.Pointer, int) {
 		}
 	}
 	if index == -1 {
+		p.mu.Unlock()
 		return nil, -1
 	}
 	var fn reflect.Value
@@ -77,24 +86,33 @@ func (p *provider) Insert(info *abi.MethodInfo) (unsafe.Pointer, int) {
 	}
 	p.n++
 	icall := icall_fn[index]
+	p.mu.Unlock()
 	return unsafe.Pointer(reflect.ValueOf(icall).Pointer()), index
 }
 
 func (p *provider) Remove(indexs []int) {
+	p.mu.Lock()
 	for _, n := range indexs {
 		if n < capacity && p.used[n] != nil {
 			p.used[n] = nil
 			p.n--
 		}
 	}
+	p.mu.Unlock()
 }
 
 func (p *provider) Available() int {
-	return capacity - p.n
+	p.mu.RLock()
+	n := capacity - p.n
+	p.mu.RUnlock()
+	return n
 }
 
 func (p *provider) Used() int {
-	return p.n
+	p.mu.RLock()
+	n := p.n
+	p.mu.RUnlock()
+	return n
 }
 
 func (p *provider) Cap() int {
@@ -102,8 +120,17 @@ func (p *provider) Cap() int {
 }
 
 func (p *provider) Clear() {
+	p.mu.Lock()
 	clear(p.used)
 	p.n = 0
+	p.mu.Unlock()
+}
+
+func (p *provider) lookup(index int) *methodUsed {
+	p.mu.RLock()
+	method := p.used[index]
+	p.mu.RUnlock()
+	return method
 }
 
 var (

--- a/icall/icall20480/icall.go
+++ b/icall/icall20480/icall.go
@@ -11,6 +11,8 @@ package icall
 
 import (
 	"reflect"
+	"runtime"
+	"sync"
 	"unsafe"
 
 	"github.com/goplus/reflectx/abi"
@@ -19,37 +21,49 @@ import (
 const capacity = 20480
 
 type provider struct {
+	mu   sync.RWMutex
 	used []*abi.MethodInfo
 	n    int
 }
 
 func (p *provider) Insert(info *abi.MethodInfo) (ifn unsafe.Pointer, index int) {
+	p.mu.Lock()
 	for i := 0; i < capacity; i++ {
 		if p.used[i] == nil {
 			p.n++
 			p.used[i] = info
 			fn := icall_array[i]
+			p.mu.Unlock()
 			return unsafe.Pointer(reflect.ValueOf(fn).Pointer()), i
 		}
 	}
+	p.mu.Unlock()
 	return nil, -1
 }
 
 func (p *provider) Available() int {
-	return capacity - p.n
+	p.mu.RLock()
+	n := capacity - p.n
+	p.mu.RUnlock()
+	return n
 }
 
 func (p *provider) Remove(indexs []int) {
+	p.mu.Lock()
 	for _, n := range indexs {
 		if n < capacity && p.used[n] != nil {
 			p.used[n] = nil
 			p.n--
 		}
 	}
+	p.mu.Unlock()
 }
 
 func (p *provider) Used() int {
-	return p.n
+	p.mu.RLock()
+	n := p.n
+	p.mu.RUnlock()
+	return n
 }
 
 func (p *provider) Cap() int {
@@ -57,8 +71,17 @@ func (p *provider) Cap() int {
 }
 
 func (p *provider) Clear() {
+	p.mu.Lock()
 	clear(p.used)
 	p.n = 0
+	p.mu.Unlock()
+}
+
+func (p *provider) lookup(index int) *abi.MethodInfo {
+	p.mu.RLock()
+	info := p.used[index]
+	p.mu.RUnlock()
+	return info
 }
 
 var (
@@ -72,7 +95,7 @@ func init() {
 }
 
 func i_x(index int, ptr unsafe.Pointer, p unsafe.Pointer) {
-	info := mp.used[index]
+	info := mp.lookup(index)
 	var receiver reflect.Value
 	if !info.Pointer && info.OnePtr {
 		receiver = reflect.NewAt(info.Type, unsafe.Pointer(&ptr)).Elem()
@@ -118,6 +141,9 @@ func i_x(index int, ptr unsafe.Pointer, p unsafe.Pointer) {
 			*(*byte)(add(p, info.InSize+i, "")) = *(*byte)(add(po, uintptr(i), ""))
 		}
 	}
+	// Context.Reset may clear the slot after lookup. Keep the copied method alive
+	// until the call returns without holding the provider lock over user code.
+	runtime.KeepAlive(info)
 }
 
 func add(p unsafe.Pointer, x uintptr, whySafe string) unsafe.Pointer {
@@ -125,6 +151,7 @@ func add(p unsafe.Pointer, x uintptr, whySafe string) unsafe.Pointer {
 }
 
 type unsafeptr = unsafe.Pointer
+
 
 var icall_array = []interface{}{
 	func(p, a unsafeptr) { i_x(0, p, unsafeptr(&a)) },

--- a/icall/icall20480/icall_regabi.go
+++ b/icall/icall20480/icall_regabi.go
@@ -5,6 +5,8 @@ package icall
 
 import (
 	"reflect"
+	"runtime"
+	"sync"
 	"unsafe"
 
 	"github.com/goplus/reflectx/abi"
@@ -18,20 +20,26 @@ type methodUsed struct {
 }
 
 type provider struct {
+	mu   sync.RWMutex
 	used []*methodUsed
 	n    int
 }
 
 func i_x(c unsafe.Pointer, frame unsafe.Pointer, retValid *bool, r unsafe.Pointer, index int) {
-	ptr := mp.used[index].ptr
+	method := mp.lookup(index)
+	ptr := method.ptr
 	moveMakeFuncArgPtrs(ptr, r)
 	callReflect(ptr, frame, retValid, r)
+	// Context.Reset may clear the slot after lookup. Keep the copied method alive
+	// until callReflect returns without holding the provider lock over user code.
+	runtime.KeepAlive(method)
 }
 
 func spillArgs()
 func unspillArgs()
 
 func (p *provider) Insert(info *abi.MethodInfo) (unsafe.Pointer, int) {
+	p.mu.Lock()
 	var index = -1
 	for i := 0; i < capacity; i++ {
 		if p.used[i] == nil {
@@ -40,6 +48,7 @@ func (p *provider) Insert(info *abi.MethodInfo) (unsafe.Pointer, int) {
 		}
 	}
 	if index == -1 {
+		p.mu.Unlock()
 		return nil, -1
 	}
 	var fn reflect.Value
@@ -77,24 +86,33 @@ func (p *provider) Insert(info *abi.MethodInfo) (unsafe.Pointer, int) {
 	}
 	p.n++
 	icall := icall_fn[index]
+	p.mu.Unlock()
 	return unsafe.Pointer(reflect.ValueOf(icall).Pointer()), index
 }
 
 func (p *provider) Remove(indexs []int) {
+	p.mu.Lock()
 	for _, n := range indexs {
 		if n < capacity && p.used[n] != nil {
 			p.used[n] = nil
 			p.n--
 		}
 	}
+	p.mu.Unlock()
 }
 
 func (p *provider) Available() int {
-	return capacity - p.n
+	p.mu.RLock()
+	n := capacity - p.n
+	p.mu.RUnlock()
+	return n
 }
 
 func (p *provider) Used() int {
-	return p.n
+	p.mu.RLock()
+	n := p.n
+	p.mu.RUnlock()
+	return n
 }
 
 func (p *provider) Cap() int {
@@ -102,8 +120,17 @@ func (p *provider) Cap() int {
 }
 
 func (p *provider) Clear() {
+	p.mu.Lock()
 	clear(p.used)
 	p.n = 0
+	p.mu.Unlock()
+}
+
+func (p *provider) lookup(index int) *methodUsed {
+	p.mu.RLock()
+	method := p.used[index]
+	p.mu.RUnlock()
+	return method
 }
 
 var (

--- a/icall/icall4096/icall.go
+++ b/icall/icall4096/icall.go
@@ -11,6 +11,8 @@ package icall
 
 import (
 	"reflect"
+	"runtime"
+	"sync"
 	"unsafe"
 
 	"github.com/goplus/reflectx/abi"
@@ -19,37 +21,49 @@ import (
 const capacity = 4096
 
 type provider struct {
+	mu   sync.RWMutex
 	used []*abi.MethodInfo
 	n    int
 }
 
 func (p *provider) Insert(info *abi.MethodInfo) (ifn unsafe.Pointer, index int) {
+	p.mu.Lock()
 	for i := 0; i < capacity; i++ {
 		if p.used[i] == nil {
 			p.n++
 			p.used[i] = info
 			fn := icall_array[i]
+			p.mu.Unlock()
 			return unsafe.Pointer(reflect.ValueOf(fn).Pointer()), i
 		}
 	}
+	p.mu.Unlock()
 	return nil, -1
 }
 
 func (p *provider) Available() int {
-	return capacity - p.n
+	p.mu.RLock()
+	n := capacity - p.n
+	p.mu.RUnlock()
+	return n
 }
 
 func (p *provider) Remove(indexs []int) {
+	p.mu.Lock()
 	for _, n := range indexs {
 		if n < capacity && p.used[n] != nil {
 			p.used[n] = nil
 			p.n--
 		}
 	}
+	p.mu.Unlock()
 }
 
 func (p *provider) Used() int {
-	return p.n
+	p.mu.RLock()
+	n := p.n
+	p.mu.RUnlock()
+	return n
 }
 
 func (p *provider) Cap() int {
@@ -57,8 +71,17 @@ func (p *provider) Cap() int {
 }
 
 func (p *provider) Clear() {
+	p.mu.Lock()
 	clear(p.used)
 	p.n = 0
+	p.mu.Unlock()
+}
+
+func (p *provider) lookup(index int) *abi.MethodInfo {
+	p.mu.RLock()
+	info := p.used[index]
+	p.mu.RUnlock()
+	return info
 }
 
 var (
@@ -72,7 +95,7 @@ func init() {
 }
 
 func i_x(index int, ptr unsafe.Pointer, p unsafe.Pointer) {
-	info := mp.used[index]
+	info := mp.lookup(index)
 	var receiver reflect.Value
 	if !info.Pointer && info.OnePtr {
 		receiver = reflect.NewAt(info.Type, unsafe.Pointer(&ptr)).Elem()
@@ -118,6 +141,9 @@ func i_x(index int, ptr unsafe.Pointer, p unsafe.Pointer) {
 			*(*byte)(add(p, info.InSize+i, "")) = *(*byte)(add(po, uintptr(i), ""))
 		}
 	}
+	// Context.Reset may clear the slot after lookup. Keep the copied method alive
+	// until the call returns without holding the provider lock over user code.
+	runtime.KeepAlive(info)
 }
 
 func add(p unsafe.Pointer, x uintptr, whySafe string) unsafe.Pointer {
@@ -125,6 +151,7 @@ func add(p unsafe.Pointer, x uintptr, whySafe string) unsafe.Pointer {
 }
 
 type unsafeptr = unsafe.Pointer
+
 
 var icall_array = []interface{}{
 	func(p, a unsafeptr) { i_x(0, p, unsafeptr(&a)) },

--- a/icall/icall4096/icall_regabi.go
+++ b/icall/icall4096/icall_regabi.go
@@ -5,6 +5,8 @@ package icall
 
 import (
 	"reflect"
+	"runtime"
+	"sync"
 	"unsafe"
 
 	"github.com/goplus/reflectx/abi"
@@ -18,20 +20,26 @@ type methodUsed struct {
 }
 
 type provider struct {
+	mu   sync.RWMutex
 	used []*methodUsed
 	n    int
 }
 
 func i_x(c unsafe.Pointer, frame unsafe.Pointer, retValid *bool, r unsafe.Pointer, index int) {
-	ptr := mp.used[index].ptr
+	method := mp.lookup(index)
+	ptr := method.ptr
 	moveMakeFuncArgPtrs(ptr, r)
 	callReflect(ptr, frame, retValid, r)
+	// Context.Reset may clear the slot after lookup. Keep the copied method alive
+	// until callReflect returns without holding the provider lock over user code.
+	runtime.KeepAlive(method)
 }
 
 func spillArgs()
 func unspillArgs()
 
 func (p *provider) Insert(info *abi.MethodInfo) (unsafe.Pointer, int) {
+	p.mu.Lock()
 	var index = -1
 	for i := 0; i < capacity; i++ {
 		if p.used[i] == nil {
@@ -40,6 +48,7 @@ func (p *provider) Insert(info *abi.MethodInfo) (unsafe.Pointer, int) {
 		}
 	}
 	if index == -1 {
+		p.mu.Unlock()
 		return nil, -1
 	}
 	var fn reflect.Value
@@ -77,24 +86,33 @@ func (p *provider) Insert(info *abi.MethodInfo) (unsafe.Pointer, int) {
 	}
 	p.n++
 	icall := icall_fn[index]
+	p.mu.Unlock()
 	return unsafe.Pointer(reflect.ValueOf(icall).Pointer()), index
 }
 
 func (p *provider) Remove(indexs []int) {
+	p.mu.Lock()
 	for _, n := range indexs {
 		if n < capacity && p.used[n] != nil {
 			p.used[n] = nil
 			p.n--
 		}
 	}
+	p.mu.Unlock()
 }
 
 func (p *provider) Available() int {
-	return capacity - p.n
+	p.mu.RLock()
+	n := capacity - p.n
+	p.mu.RUnlock()
+	return n
 }
 
 func (p *provider) Used() int {
-	return p.n
+	p.mu.RLock()
+	n := p.n
+	p.mu.RUnlock()
+	return n
 }
 
 func (p *provider) Cap() int {
@@ -102,8 +120,17 @@ func (p *provider) Cap() int {
 }
 
 func (p *provider) Clear() {
+	p.mu.Lock()
 	clear(p.used)
 	p.n = 0
+	p.mu.Unlock()
+}
+
+func (p *provider) lookup(index int) *methodUsed {
+	p.mu.RLock()
+	method := p.used[index]
+	p.mu.RUnlock()
+	return method
 }
 
 var (

--- a/icall/icall512/icall.go
+++ b/icall/icall512/icall.go
@@ -11,6 +11,8 @@ package icall
 
 import (
 	"reflect"
+	"runtime"
+	"sync"
 	"unsafe"
 
 	"github.com/goplus/reflectx/abi"
@@ -19,37 +21,49 @@ import (
 const capacity = 512
 
 type provider struct {
+	mu   sync.RWMutex
 	used []*abi.MethodInfo
 	n    int
 }
 
 func (p *provider) Insert(info *abi.MethodInfo) (ifn unsafe.Pointer, index int) {
+	p.mu.Lock()
 	for i := 0; i < capacity; i++ {
 		if p.used[i] == nil {
 			p.n++
 			p.used[i] = info
 			fn := icall_array[i]
+			p.mu.Unlock()
 			return unsafe.Pointer(reflect.ValueOf(fn).Pointer()), i
 		}
 	}
+	p.mu.Unlock()
 	return nil, -1
 }
 
 func (p *provider) Available() int {
-	return capacity - p.n
+	p.mu.RLock()
+	n := capacity - p.n
+	p.mu.RUnlock()
+	return n
 }
 
 func (p *provider) Remove(indexs []int) {
+	p.mu.Lock()
 	for _, n := range indexs {
 		if n < capacity && p.used[n] != nil {
 			p.used[n] = nil
 			p.n--
 		}
 	}
+	p.mu.Unlock()
 }
 
 func (p *provider) Used() int {
-	return p.n
+	p.mu.RLock()
+	n := p.n
+	p.mu.RUnlock()
+	return n
 }
 
 func (p *provider) Cap() int {
@@ -57,8 +71,17 @@ func (p *provider) Cap() int {
 }
 
 func (p *provider) Clear() {
+	p.mu.Lock()
 	clear(p.used)
 	p.n = 0
+	p.mu.Unlock()
+}
+
+func (p *provider) lookup(index int) *abi.MethodInfo {
+	p.mu.RLock()
+	info := p.used[index]
+	p.mu.RUnlock()
+	return info
 }
 
 var (
@@ -72,7 +95,7 @@ func init() {
 }
 
 func i_x(index int, ptr unsafe.Pointer, p unsafe.Pointer) {
-	info := mp.used[index]
+	info := mp.lookup(index)
 	var receiver reflect.Value
 	if !info.Pointer && info.OnePtr {
 		receiver = reflect.NewAt(info.Type, unsafe.Pointer(&ptr)).Elem()
@@ -118,6 +141,9 @@ func i_x(index int, ptr unsafe.Pointer, p unsafe.Pointer) {
 			*(*byte)(add(p, info.InSize+i, "")) = *(*byte)(add(po, uintptr(i), ""))
 		}
 	}
+	// Context.Reset may clear the slot after lookup. Keep the copied method alive
+	// until the call returns without holding the provider lock over user code.
+	runtime.KeepAlive(info)
 }
 
 func add(p unsafe.Pointer, x uintptr, whySafe string) unsafe.Pointer {
@@ -125,6 +151,7 @@ func add(p unsafe.Pointer, x uintptr, whySafe string) unsafe.Pointer {
 }
 
 type unsafeptr = unsafe.Pointer
+
 
 var icall_array = []interface{}{
 	func(p, a unsafeptr) { i_x(0, p, unsafeptr(&a)) },

--- a/icall/icall512/icall_regabi.go
+++ b/icall/icall512/icall_regabi.go
@@ -5,6 +5,8 @@ package icall
 
 import (
 	"reflect"
+	"runtime"
+	"sync"
 	"unsafe"
 
 	"github.com/goplus/reflectx/abi"
@@ -18,20 +20,26 @@ type methodUsed struct {
 }
 
 type provider struct {
+	mu   sync.RWMutex
 	used []*methodUsed
 	n    int
 }
 
 func i_x(c unsafe.Pointer, frame unsafe.Pointer, retValid *bool, r unsafe.Pointer, index int) {
-	ptr := mp.used[index].ptr
+	method := mp.lookup(index)
+	ptr := method.ptr
 	moveMakeFuncArgPtrs(ptr, r)
 	callReflect(ptr, frame, retValid, r)
+	// Context.Reset may clear the slot after lookup. Keep the copied method alive
+	// until callReflect returns without holding the provider lock over user code.
+	runtime.KeepAlive(method)
 }
 
 func spillArgs()
 func unspillArgs()
 
 func (p *provider) Insert(info *abi.MethodInfo) (unsafe.Pointer, int) {
+	p.mu.Lock()
 	var index = -1
 	for i := 0; i < capacity; i++ {
 		if p.used[i] == nil {
@@ -40,6 +48,7 @@ func (p *provider) Insert(info *abi.MethodInfo) (unsafe.Pointer, int) {
 		}
 	}
 	if index == -1 {
+		p.mu.Unlock()
 		return nil, -1
 	}
 	var fn reflect.Value
@@ -77,24 +86,33 @@ func (p *provider) Insert(info *abi.MethodInfo) (unsafe.Pointer, int) {
 	}
 	p.n++
 	icall := icall_fn[index]
+	p.mu.Unlock()
 	return unsafe.Pointer(reflect.ValueOf(icall).Pointer()), index
 }
 
 func (p *provider) Remove(indexs []int) {
+	p.mu.Lock()
 	for _, n := range indexs {
 		if n < capacity && p.used[n] != nil {
 			p.used[n] = nil
 			p.n--
 		}
 	}
+	p.mu.Unlock()
 }
 
 func (p *provider) Available() int {
-	return capacity - p.n
+	p.mu.RLock()
+	n := capacity - p.n
+	p.mu.RUnlock()
+	return n
 }
 
 func (p *provider) Used() int {
-	return p.n
+	p.mu.RLock()
+	n := p.n
+	p.mu.RUnlock()
+	return n
 }
 
 func (p *provider) Cap() int {
@@ -102,8 +120,17 @@ func (p *provider) Cap() int {
 }
 
 func (p *provider) Clear() {
+	p.mu.Lock()
 	clear(p.used)
 	p.n = 0
+	p.mu.Unlock()
+}
+
+func (p *provider) lookup(index int) *methodUsed {
+	p.mu.RLock()
+	method := p.used[index]
+	p.mu.RUnlock()
+	return method
 }
 
 var (

--- a/icall/icall8192/icall.go
+++ b/icall/icall8192/icall.go
@@ -11,6 +11,8 @@ package icall
 
 import (
 	"reflect"
+	"runtime"
+	"sync"
 	"unsafe"
 
 	"github.com/goplus/reflectx/abi"
@@ -19,37 +21,49 @@ import (
 const capacity = 8192
 
 type provider struct {
+	mu   sync.RWMutex
 	used []*abi.MethodInfo
 	n    int
 }
 
 func (p *provider) Insert(info *abi.MethodInfo) (ifn unsafe.Pointer, index int) {
+	p.mu.Lock()
 	for i := 0; i < capacity; i++ {
 		if p.used[i] == nil {
 			p.n++
 			p.used[i] = info
 			fn := icall_array[i]
+			p.mu.Unlock()
 			return unsafe.Pointer(reflect.ValueOf(fn).Pointer()), i
 		}
 	}
+	p.mu.Unlock()
 	return nil, -1
 }
 
 func (p *provider) Available() int {
-	return capacity - p.n
+	p.mu.RLock()
+	n := capacity - p.n
+	p.mu.RUnlock()
+	return n
 }
 
 func (p *provider) Remove(indexs []int) {
+	p.mu.Lock()
 	for _, n := range indexs {
 		if n < capacity && p.used[n] != nil {
 			p.used[n] = nil
 			p.n--
 		}
 	}
+	p.mu.Unlock()
 }
 
 func (p *provider) Used() int {
-	return p.n
+	p.mu.RLock()
+	n := p.n
+	p.mu.RUnlock()
+	return n
 }
 
 func (p *provider) Cap() int {
@@ -57,8 +71,17 @@ func (p *provider) Cap() int {
 }
 
 func (p *provider) Clear() {
+	p.mu.Lock()
 	clear(p.used)
 	p.n = 0
+	p.mu.Unlock()
+}
+
+func (p *provider) lookup(index int) *abi.MethodInfo {
+	p.mu.RLock()
+	info := p.used[index]
+	p.mu.RUnlock()
+	return info
 }
 
 var (
@@ -72,7 +95,7 @@ func init() {
 }
 
 func i_x(index int, ptr unsafe.Pointer, p unsafe.Pointer) {
-	info := mp.used[index]
+	info := mp.lookup(index)
 	var receiver reflect.Value
 	if !info.Pointer && info.OnePtr {
 		receiver = reflect.NewAt(info.Type, unsafe.Pointer(&ptr)).Elem()
@@ -118,6 +141,9 @@ func i_x(index int, ptr unsafe.Pointer, p unsafe.Pointer) {
 			*(*byte)(add(p, info.InSize+i, "")) = *(*byte)(add(po, uintptr(i), ""))
 		}
 	}
+	// Context.Reset may clear the slot after lookup. Keep the copied method alive
+	// until the call returns without holding the provider lock over user code.
+	runtime.KeepAlive(info)
 }
 
 func add(p unsafe.Pointer, x uintptr, whySafe string) unsafe.Pointer {
@@ -125,6 +151,7 @@ func add(p unsafe.Pointer, x uintptr, whySafe string) unsafe.Pointer {
 }
 
 type unsafeptr = unsafe.Pointer
+
 
 var icall_array = []interface{}{
 	func(p, a unsafeptr) { i_x(0, p, unsafeptr(&a)) },

--- a/icall/icall8192/icall_regabi.go
+++ b/icall/icall8192/icall_regabi.go
@@ -5,6 +5,8 @@ package icall
 
 import (
 	"reflect"
+	"runtime"
+	"sync"
 	"unsafe"
 
 	"github.com/goplus/reflectx/abi"
@@ -18,20 +20,26 @@ type methodUsed struct {
 }
 
 type provider struct {
+	mu   sync.RWMutex
 	used []*methodUsed
 	n    int
 }
 
 func i_x(c unsafe.Pointer, frame unsafe.Pointer, retValid *bool, r unsafe.Pointer, index int) {
-	ptr := mp.used[index].ptr
+	method := mp.lookup(index)
+	ptr := method.ptr
 	moveMakeFuncArgPtrs(ptr, r)
 	callReflect(ptr, frame, retValid, r)
+	// Context.Reset may clear the slot after lookup. Keep the copied method alive
+	// until callReflect returns without holding the provider lock over user code.
+	runtime.KeepAlive(method)
 }
 
 func spillArgs()
 func unspillArgs()
 
 func (p *provider) Insert(info *abi.MethodInfo) (unsafe.Pointer, int) {
+	p.mu.Lock()
 	var index = -1
 	for i := 0; i < capacity; i++ {
 		if p.used[i] == nil {
@@ -40,6 +48,7 @@ func (p *provider) Insert(info *abi.MethodInfo) (unsafe.Pointer, int) {
 		}
 	}
 	if index == -1 {
+		p.mu.Unlock()
 		return nil, -1
 	}
 	var fn reflect.Value
@@ -77,24 +86,33 @@ func (p *provider) Insert(info *abi.MethodInfo) (unsafe.Pointer, int) {
 	}
 	p.n++
 	icall := icall_fn[index]
+	p.mu.Unlock()
 	return unsafe.Pointer(reflect.ValueOf(icall).Pointer()), index
 }
 
 func (p *provider) Remove(indexs []int) {
+	p.mu.Lock()
 	for _, n := range indexs {
 		if n < capacity && p.used[n] != nil {
 			p.used[n] = nil
 			p.n--
 		}
 	}
+	p.mu.Unlock()
 }
 
 func (p *provider) Available() int {
-	return capacity - p.n
+	p.mu.RLock()
+	n := capacity - p.n
+	p.mu.RUnlock()
+	return n
 }
 
 func (p *provider) Used() int {
-	return p.n
+	p.mu.RLock()
+	n := p.n
+	p.mu.RUnlock()
+	return n
 }
 
 func (p *provider) Cap() int {
@@ -102,8 +120,17 @@ func (p *provider) Cap() int {
 }
 
 func (p *provider) Clear() {
+	p.mu.Lock()
 	clear(p.used)
 	p.n = 0
+	p.mu.Unlock()
+}
+
+func (p *provider) lookup(index int) *methodUsed {
+	p.mu.RLock()
+	method := p.used[index]
+	p.mu.RUnlock()
+	return method
 }
 
 var (

--- a/internal/icall512/icall.go
+++ b/internal/icall512/icall.go
@@ -11,6 +11,8 @@ package icall
 
 import (
 	"reflect"
+	"runtime"
+	"sync"
 	"unsafe"
 
 	"github.com/goplus/reflectx/abi"
@@ -19,37 +21,49 @@ import (
 const capacity = 512
 
 type provider struct {
+	mu   sync.RWMutex
 	used []*abi.MethodInfo
 	n    int
 }
 
 func (p *provider) Insert(info *abi.MethodInfo) (ifn unsafe.Pointer, index int) {
+	p.mu.Lock()
 	for i := 0; i < capacity; i++ {
 		if p.used[i] == nil {
 			p.n++
 			p.used[i] = info
 			fn := icall_array[i]
+			p.mu.Unlock()
 			return unsafe.Pointer(reflect.ValueOf(fn).Pointer()), i
 		}
 	}
+	p.mu.Unlock()
 	return nil, -1
 }
 
 func (p *provider) Available() int {
-	return capacity - p.n
+	p.mu.RLock()
+	n := capacity - p.n
+	p.mu.RUnlock()
+	return n
 }
 
 func (p *provider) Remove(indexs []int) {
+	p.mu.Lock()
 	for _, n := range indexs {
 		if n < capacity && p.used[n] != nil {
 			p.used[n] = nil
 			p.n--
 		}
 	}
+	p.mu.Unlock()
 }
 
 func (p *provider) Used() int {
-	return p.n
+	p.mu.RLock()
+	n := p.n
+	p.mu.RUnlock()
+	return n
 }
 
 func (p *provider) Cap() int {
@@ -57,8 +71,17 @@ func (p *provider) Cap() int {
 }
 
 func (p *provider) Clear() {
+	p.mu.Lock()
 	clear(p.used)
 	p.n = 0
+	p.mu.Unlock()
+}
+
+func (p *provider) lookup(index int) *abi.MethodInfo {
+	p.mu.RLock()
+	info := p.used[index]
+	p.mu.RUnlock()
+	return info
 }
 
 var (
@@ -72,7 +95,7 @@ func init() {
 }
 
 func i_x(index int, ptr unsafe.Pointer, p unsafe.Pointer) {
-	info := mp.used[index]
+	info := mp.lookup(index)
 	var receiver reflect.Value
 	if !info.Pointer && info.OnePtr {
 		receiver = reflect.NewAt(info.Type, unsafe.Pointer(&ptr)).Elem()
@@ -118,6 +141,9 @@ func i_x(index int, ptr unsafe.Pointer, p unsafe.Pointer) {
 			*(*byte)(add(p, info.InSize+i, "")) = *(*byte)(add(po, uintptr(i), ""))
 		}
 	}
+	// Context.Reset may clear the slot after lookup. Keep the copied method alive
+	// until the call returns without holding the provider lock over user code.
+	runtime.KeepAlive(info)
 }
 
 func add(p unsafe.Pointer, x uintptr, whySafe string) unsafe.Pointer {
@@ -125,6 +151,7 @@ func add(p unsafe.Pointer, x uintptr, whySafe string) unsafe.Pointer {
 }
 
 type unsafeptr = unsafe.Pointer
+
 
 var icall_array = []interface{}{
 	func(p, a unsafeptr) { i_x(0, p, unsafeptr(&a)) },

--- a/internal/icall512/icall_regabi.go
+++ b/internal/icall512/icall_regabi.go
@@ -5,6 +5,8 @@ package icall
 
 import (
 	"reflect"
+	"runtime"
+	"sync"
 	"unsafe"
 
 	"github.com/goplus/reflectx/abi"
@@ -18,20 +20,26 @@ type methodUsed struct {
 }
 
 type provider struct {
+	mu   sync.RWMutex
 	used []*methodUsed
 	n    int
 }
 
 func i_x(c unsafe.Pointer, frame unsafe.Pointer, retValid *bool, r unsafe.Pointer, index int) {
-	ptr := mp.used[index].ptr
+	method := mp.lookup(index)
+	ptr := method.ptr
 	moveMakeFuncArgPtrs(ptr, r)
 	callReflect(ptr, frame, retValid, r)
+	// Context.Reset may clear the slot after lookup. Keep the copied method alive
+	// until callReflect returns without holding the provider lock over user code.
+	runtime.KeepAlive(method)
 }
 
 func spillArgs()
 func unspillArgs()
 
 func (p *provider) Insert(info *abi.MethodInfo) (unsafe.Pointer, int) {
+	p.mu.Lock()
 	var index = -1
 	for i := 0; i < capacity; i++ {
 		if p.used[i] == nil {
@@ -40,6 +48,7 @@ func (p *provider) Insert(info *abi.MethodInfo) (unsafe.Pointer, int) {
 		}
 	}
 	if index == -1 {
+		p.mu.Unlock()
 		return nil, -1
 	}
 	var fn reflect.Value
@@ -77,24 +86,33 @@ func (p *provider) Insert(info *abi.MethodInfo) (unsafe.Pointer, int) {
 	}
 	p.n++
 	icall := icall_fn[index]
+	p.mu.Unlock()
 	return unsafe.Pointer(reflect.ValueOf(icall).Pointer()), index
 }
 
 func (p *provider) Remove(indexs []int) {
+	p.mu.Lock()
 	for _, n := range indexs {
 		if n < capacity && p.used[n] != nil {
 			p.used[n] = nil
 			p.n--
 		}
 	}
+	p.mu.Unlock()
 }
 
 func (p *provider) Available() int {
-	return capacity - p.n
+	p.mu.RLock()
+	n := capacity - p.n
+	p.mu.RUnlock()
+	return n
 }
 
 func (p *provider) Used() int {
-	return p.n
+	p.mu.RLock()
+	n := p.n
+	p.mu.RUnlock()
+	return n
 }
 
 func (p *provider) Cap() int {
@@ -102,8 +120,17 @@ func (p *provider) Cap() int {
 }
 
 func (p *provider) Clear() {
+	p.mu.Lock()
 	clear(p.used)
 	p.n = 0
+	p.mu.Unlock()
+}
+
+func (p *provider) lookup(index int) *methodUsed {
+	p.mu.RLock()
+	method := p.used[index]
+	p.mu.RUnlock()
+	return method
 }
 
 var (

--- a/internal/icall512/provider_test.go
+++ b/internal/icall512/provider_test.go
@@ -1,0 +1,55 @@
+package icall
+
+import (
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/goplus/reflectx/abi"
+)
+
+type providerTestReceiver struct{}
+
+func TestProviderConcurrentAccess(t *testing.T) {
+	mp.Clear()
+	t.Cleanup(mp.Clear)
+
+	info := &abi.MethodInfo{
+		Func:    reflect.ValueOf(func(*providerTestReceiver) {}),
+		Type:    reflect.TypeOf(providerTestReceiver{}),
+		Pointer: true,
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 1000; j++ {
+				_, index := mp.Insert(info)
+				if index >= 0 {
+					mp.Remove([]int{index})
+				}
+			}
+		}()
+	}
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < 1000; j++ {
+				_ = mp.lookup(0)
+				_ = mp.Used()
+				_ = mp.Available()
+			}
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for j := 0; j < 1000; j++ {
+			mp.Clear()
+		}
+	}()
+	wg.Wait()
+}

--- a/provider_concurrency_test.go
+++ b/provider_concurrency_test.go
@@ -1,0 +1,78 @@
+package reflectx_test
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/goplus/reflectx"
+)
+
+func TestMethodCallDoesNotBlockProviderWrites(t *testing.T) {
+	callCtx := reflectx.NewContext()
+	t.Cleanup(callCtx.Reset)
+	entered := make(chan struct{})
+	release := make(chan struct{})
+
+	callType := callCtx.NamedStructOf("test", "ProviderCall", nil)
+	callType = callCtx.NewMethodSet(callType, 1, 1)
+	err := callCtx.SetMethodSet(callType, []reflectx.Method{
+		reflectx.MakeMethod(
+			"Wait",
+			"test",
+			false,
+			reflect.TypeOf(func() {}),
+			func([]reflect.Value) []reflect.Value {
+				close(entered)
+				<-release
+				return nil
+			},
+		),
+	}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	callDone := make(chan struct{})
+	go func() {
+		reflect.New(callType).Elem().MethodByName("Wait").Call(nil)
+		close(callDone)
+	}()
+	select {
+	case <-entered:
+	case <-time.After(time.Second):
+		close(release)
+		t.Fatal("dynamic method did not start")
+	}
+
+	registerCtx := reflectx.NewContext()
+	t.Cleanup(registerCtx.Reset)
+	registerType := registerCtx.NamedStructOf("test", "ProviderRegister", nil)
+	registerType = registerCtx.NewMethodSet(registerType, 1, 1)
+	registerDone := make(chan error, 1)
+	go func() {
+		registerDone <- registerCtx.SetMethodSet(registerType, []reflectx.Method{
+			reflectx.MakeMethod(
+				"Run",
+				"test",
+				false,
+				reflect.TypeOf(func() {}),
+				func([]reflect.Value) []reflect.Value { return nil },
+			),
+		}, false)
+	}()
+
+	select {
+	case err := <-registerDone:
+		close(release)
+		<-callDone
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(time.Second):
+		close(release)
+		<-callDone
+		<-registerDone
+		t.Fatal("method registration blocked on a running method call")
+	}
+}


### PR DESCRIPTION
Method providers can be accessed concurrently when multiple ixgo interpreters are active. A concrete example is LLAR executing a formula hook from interpreter A while GC cleanup releases interpreter B: A enters `i_x` and reads a method slot, while B runs `UnsafeRelease`, then `Context.Reset`, and finally `MethodProvider.Remove` against the same provider state. Without provider-level synchronization, callers must serialize entire interpreted calls to avoid races.

The implementation includes:

- Add a `sync.RWMutex` to each generated method provider and protect `Insert`, `Remove`, `Clear`, `Used`, and `Available`.
- Copy the selected method under a short read lock in `i_x`, then release the lock before invoking user code so a long-running method does not block method registration or cleanup.
- Keep the copied `MethodInfo` or `methodUsed` alive until the call returns, allowing `Context.Reset` to clear the original slot safely.
- Update both legacy ABI and register ABI templates in `cmd/icall_gen`, then regenerate every checked-in icall provider.
- Add race coverage for concurrent provider operations and verify that a running dynamic method does not block another context from registering methods.

This moves icall slot synchronization into the component that owns the slots and allows independent interpreters to run and be released concurrently without holding a caller-wide lock over user code.